### PR TITLE
Use cron for auto-assign trigger

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,7 +1,8 @@
 name: Auto Assign Reviewers
 
 on:
-  - pull_request
+  schedule:
+    - cron: "*/5 * * * *"
 
 jobs:
   assign_reviewer:


### PR DESCRIPTION
Forks do not have write permission, and so any PRs from forks cannot add reviewers. Example failed run https://github.com/googleinterns/step191-2020/runs/820390662?check_suite_focus=true

This will run the auto-assign workflow every 5 minutes to see if reviewers should be added based on the file changes.
