### PR TITLE
Remove starter projects from cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,13 +2,3 @@ steps:
   - name: maven
     entrypoint: mvn
     args: ['-f', './', 'package']
-  - name: maven
-    entrypoint: mvn
-    args: ['-f', './starters/pamelalozano', 'package']
-  - name: maven
-    entrypoint: mvn
-    args: ['-f', './starters/aroquev/portfolio', 'package']
-  - name: maven
-    entrypoint: mvn
-    args: ['-f', './starters/ayup/portfolio', 'package']
-    


### PR DESCRIPTION
No need to keep building them now that we're done with the starter projects.