### PR TITLE
Ignore tests in Maven "target" directory.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -148,9 +148,9 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: [
+    "/target/",
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],


### PR DESCRIPTION
Ignores test files copied to "target" directory so Jest doesn't run them twice.