### PR TITLE
Join link

### DIFF
--- a/src/main/java/com/google/sps/daos/DatabaseUserDao.java
+++ b/src/main/java/com/google/sps/daos/DatabaseUserDao.java
@@ -117,6 +117,8 @@ public class DatabaseUserDao implements UserDao {
     
   }
 
+  // Register a user in a gameInstance and return its newly assigned animal alias
+  // If user is already registered, just return the animal alias that was already assigned before
   @Override
   public String joinGameInstance(String idToken, String gameInstanceId) {
     FirebaseToken decodedToken = null;
@@ -158,6 +160,8 @@ public class DatabaseUserDao implements UserDao {
 
     // Add the active GameInstance to the User's entry in "Users" collection
     firestoreDb.collection("users").document(userId).update("activeGameInstanceId", gameInstanceId);
+
+    // Return the animal that was assigned to the user
     return animal;
   }
 

--- a/src/main/java/com/google/sps/daos/UserDao.java
+++ b/src/main/java/com/google/sps/daos/UserDao.java
@@ -1,7 +1,11 @@
 package com.google.sps.daos;
 
 public interface UserDao {
+  
+  // Register a user in a gameInstance and return its newly assigned animal alias
+  // If user is already registered, just return the animal alias that was already assigned before
   public String joinGameInstance(String idToken, String gameInstanceId);
+
   public void createIfNotExists(String idToken);
 
 }

--- a/src/main/java/com/google/sps/daos/UserDao.java
+++ b/src/main/java/com/google/sps/daos/UserDao.java
@@ -1,7 +1,7 @@
 package com.google.sps.daos;
 
 public interface UserDao {
-  public void joinGameInstance(String idToken, String gameInstanceId);
+  public String joinGameInstance(String idToken, String gameInstanceId);
   public void createIfNotExists(String idToken);
 
 }

--- a/src/main/java/com/google/sps/servlets/JoinGameInstanceServlet.java
+++ b/src/main/java/com/google/sps/servlets/JoinGameInstanceServlet.java
@@ -51,9 +51,11 @@ public class JoinGameInstanceServlet extends HttpServlet {
 
     UserDao dao = (UserDao) this.getServletContext().getAttribute("userDao");
 
+    // Register a user in a gameInstance and get its newly assigned animal alias to return it to the client
+    // If user is already registered, just get the animal alias that was already assigned before 
     String animal = dao.joinGameInstance(jsonObj.get("idToken").getAsString(), jsonObj.get("gameInstanceId").getAsString());
     
-    // Convert the newGameInstanceId to JSON
+    // Convert the anima alias to JSON
     String json = convertToJson(animal);
     // Send the JSON as response
     response.setContentType("application/json;");

--- a/src/main/java/com/google/sps/servlets/JoinGameInstanceServlet.java
+++ b/src/main/java/com/google/sps/servlets/JoinGameInstanceServlet.java
@@ -51,7 +51,22 @@ public class JoinGameInstanceServlet extends HttpServlet {
 
     UserDao dao = (UserDao) this.getServletContext().getAttribute("userDao");
 
-    dao.joinGameInstance(jsonObj.get("idToken").getAsString(), jsonObj.get("gameInstanceId").getAsString());
+    String animal = dao.joinGameInstance(jsonObj.get("idToken").getAsString(), jsonObj.get("gameInstanceId").getAsString());
+    
+    // Convert the newGameInstanceId to JSON
+    String json = convertToJson(animal);
+    // Send the JSON as response
+    response.setContentType("application/json;");
+    response.getWriter().println(json);
+  }
+
+  /**
+   * Convert to JSON using Gson
+   */
+  private String convertToJson(String newGameInstanceId) {
+    Gson gson = new Gson();
+    String json = gson.toJson(newGameInstanceId);
+    return json;
   }
 
 }

--- a/src/main/webapp/student/scripts/enter-game.js
+++ b/src/main/webapp/student/scripts/enter-game.js
@@ -50,21 +50,7 @@ function verifyGameInstanceExists(gameInstanceId) {
 
 // Send the request to join the Game Instance
 function joinGameInstance(gameInstanceId) {
-  firebase.auth().currentUser.getIdToken(/* forceRefresh */ true).then(function(idToken) {
-    fetch('/joinGameInstance', {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({idToken: idToken, gameInstanceId: gameInstanceId})
-    }).then(() => {
-      window.location.href = "/student/play-game.html?gameInstanceId=" + gameInstanceId;
-    });
-  }).catch(function(error) {
-    // Handle error
-    console.log("Please log in");
-  });
+  window.location.href = "/student/play-game.html?gameInstanceId=" + gameInstanceId;
 }
 
 // Display a message saying that GameInstanceId is not valid

--- a/src/main/webapp/student/scripts/play-game.js
+++ b/src/main/webapp/student/scripts/play-game.js
@@ -62,7 +62,7 @@ async function loadGamePanel(user) {
   initGameInstanceListener(gameInstanceId);
 }
 
-// Register and get animal alias from Firestore, or if exists just retrieve animal alias
+// Register and get animal alias from Firestore, or if exists just retrieve assigned animal alias
 function registerStudentInGameInstance(gameInstanceId) {
   firebase.auth().currentUser.getIdToken(/* forceRefresh */ true).then(function(idToken) {
     fetch('/joinGameInstance', {

--- a/src/main/webapp/student/scripts/play-game.js
+++ b/src/main/webapp/student/scripts/play-game.js
@@ -20,7 +20,7 @@ let active = false;
 let currentQuestionId = null;
 let selectedAnswerId = "";
 let currentQuestionActive = false;
-let gameInstanceId = getGameInstanceIdFromQueryParams();
+let gameInstanceId = null; 
 const resultObject = document.getElementById("result");
 let submited = false;
 let isFinished = false;
@@ -49,23 +49,45 @@ function authStateObserver(user) {
 async function loadGamePanel(user) {
   // Get the Game Instance's ID in which the user is participating
   
+  gameInstanceId = getGameInstanceIdFromQueryParams();
+
   if (gameInstanceId == null) {
     gameInstanceId = await getActiveGameInstanceId(user);
   }
 
+  // Register and get animal alias from Firestore, or if exists just retrieve animal alias
+  registerStudentInGameInstance(gameInstanceId);
+
   // Start listening to the GameInstance
   initGameInstanceListener(gameInstanceId);
-
-  // Get and display the user's id and alias
-  initStudentAlias(user, gameInstanceId);
 }
 
-// // Get and display the user's id and alias in the UI
-function initStudentAlias(user, gameInstanceId) {
-  db.collection("gameInstance").doc(gameInstanceId).collection("students").doc(user.uid).get().then(function(doc) {
-    const userIdDivElement = document.getElementById('userId');
-    userIdDivElement.innerText = `You are: ${doc.data().alias}`
+// Register and get animal alias from Firestore, or if exists just retrieve animal alias
+function registerStudentInGameInstance(gameInstanceId) {
+  firebase.auth().currentUser.getIdToken(/* forceRefresh */ true).then(function(idToken) {
+    fetch('/joinGameInstance', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({idToken: idToken, gameInstanceId: gameInstanceId})
+    }).then((response) => {
+      response.json().then(animal => {
+        // Display the user's alias
+        initStudentAlias(animal);
+      });
+    });
+  }).catch(function(error) {
+    // Handle error
+    console.log("Please log in");
   });
+}
+
+// Display the user's alias in the UI
+function initStudentAlias(animalAlias) {
+  const userIdDivElement = document.getElementById('userId');
+  userIdDivElement.innerText = `You are: ${animalAlias}`
 }
 
 // Gets the gameInstanceId from the query string if there is

--- a/src/main/webapp/teacher/controlGameInstance/controlGameInstance.css
+++ b/src/main/webapp/teacher/controlGameInstance/controlGameInstance.css
@@ -28,3 +28,18 @@
 #cardActions {
   text-align: center;
 }
+
+#jsShareGameInstance {
+  color: red;
+  cursor: pointer;
+}
+
+#jsShareGameInstance:hover {
+  color: blue;
+  cursor: pointer;
+}
+
+#jsShareGameInstance:active {
+  color: gray;
+  cursor: pointer;
+}

--- a/src/main/webapp/teacher/controlGameInstance/controlGameInstance.html
+++ b/src/main/webapp/teacher/controlGameInstance/controlGameInstance.html
@@ -88,6 +88,7 @@
             <div class="mdl-card__supporting-text">
               <div id="gameInfo">
                 <div id="jsGameInstanceId"></div>
+                <div id="jsShareGameInstance"></div>
                 <div id="jsNumberOfStudents"></div>
                 <div id="jsGameDetails">
                   <div id="jsGameId"></div>

--- a/src/main/webapp/teacher/controlGameInstance/controlGameInstance.js
+++ b/src/main/webapp/teacher/controlGameInstance/controlGameInstance.js
@@ -148,6 +148,9 @@ function buildActiveGameInstanceUI({ gameInstanceId, gameInstance, game} = {}) {
 function addGameInstanceIdToUI(gameInstanceId) {
   const gameInstanceIdElement = document.getElementById("jsGameInstanceId");
   gameInstanceIdElement.innerText = "This gameInstance's ID is: " + gameInstanceId;
+
+  const shareGameInstanceElement = document.getElementById('jsShareGameInstance');
+  shareGameInstanceElement.innerText = "Share this link with your students for them to join: " + "https://quizzy-step-2020.uc.r.appspot.com/student/play-game.html?gameInstanceId=" + gameInstanceId;
 }
 
 // Adds the Game's details to the UI
@@ -479,9 +482,7 @@ function addQuestionAnswerToHistoryUI({ questionId, answerId, answer } = {}) {
   answerInQuestionStatsDivElement.innerText = answer.title + ' with ' + answer.numberAnswers + ' answers.';
 
   if (answer.correct) {
-    questionAnswerDivElement.innerText = 'Correctly answered, chose: "' + answer.chosen + '"';
-  } else {
-    questionAnswerDivElement.innerText = 'Incorrect answer, chose: "' + answer.chosen + '"';
+    answerInQuestionStatsDivElement.innerText += ' (Correct answer)';
   }
 
   // Add the answer to its component in the DOM

--- a/src/main/webapp/teacher/controlGameInstance/controlGameInstance.js
+++ b/src/main/webapp/teacher/controlGameInstance/controlGameInstance.js
@@ -150,7 +150,10 @@ function addGameInstanceIdToUI(gameInstanceId) {
   gameInstanceIdElement.innerText = "This gameInstance's ID is: " + gameInstanceId;
 
   const shareGameInstanceElement = document.getElementById('jsShareGameInstance');
-  shareGameInstanceElement.innerText = "Share this link with your students for them to join: " + "https://quizzy-step-2020.uc.r.appspot.com/student/play-game.html?gameInstanceId=" + gameInstanceId;
+  shareGameInstanceElement.innerText = "Share this link with your students for them to join (click to copy to clipboard): " + "https://quizzy-step-2020.uc.r.appspot.com/student/play-game.html?gameInstanceId=" + gameInstanceId;
+  shareGameInstanceElement.addEventListener('click', () => {
+    navigator.clipboard.writeText("https://quizzy-step-2020.uc.r.appspot.com/student/play-game.html?gameInstanceId=" + gameInstanceId);
+  });
 }
 
 // Adds the Game's details to the UI


### PR DESCRIPTION
LAST PRRRRR
Now when the teacher creates a gameInstance there is a link the teacher can share with the students for them to join. If the teacher clicks the link it gets copied to the clipboard so that its ready to be shared with the students.

I moved the process so that when the student introduces the room code in the join page, it only redirects to the play screen, and now that is where the POST request is sent to the back end for the student to be registered and assigned an animal alias. Actually this is better because we now have one query instead of two as previously.

![image](https://user-images.githubusercontent.com/43384970/91482243-601ed700-e86b-11ea-924d-e72b7e3ec2ee.png)

